### PR TITLE
fix: README.md's compose example was pointing to old image

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Example Docker Compose Configuration
 ====================================
 
     radius:
-      image: vvlasy/freeradius-ldap:master
+      image: vvlasy/freeradius-ldap-authentik:master
       ports:
         - "1812:1812/udp"
         - "1813:1813/udp"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Example Docker Compose Configuration
 ====================================
 
     radius:
-      image: irasnyd/freeradius-ldap:latest
+      image: vvlasy/freeradius-ldap:master
       ports:
         - "1812:1812/udp"
         - "1813:1813/udp"


### PR DESCRIPTION
Changed the `radius` service image from `irasnyd/freeradius-ldap:latest` to `vvlasy/freeradius-ldap:master`.

Had me confused for a while as I'd completely missed it - figured this might be useful for future users using this for wireless auth.